### PR TITLE
Command line arguments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea
 cmake-build-debug
+build

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.idea
+cmake-build-debug

--- a/FTSPlotMain.cpp
+++ b/FTSPlotMain.cpp
@@ -19,26 +19,58 @@
 #include <QTextStream>
 #include <QCoreApplication>
 #include "mainwindow.h"
+#include "FTSPrep.h"
 #include <iostream>
 #include <QtDebug>
 
 #ifdef Q_WS_X11
+
 #include <X11/Xlib.h>
+
 #endif
 
 
 using namespace std;
 
-int main ( int argc, char *argv[] )
-{
+bool isnt_config_file(char *filename) {
+    unsigned length = strlen(filename);
+    return strcmp(filename + (length - 4), ".cfg");
+}
+
+void preprocess(int argc, char *argv[]) {
+    FTSPrep ftsPrep;
+
+    for (unsigned i = 1; i < argc; i++) {
+        if (isnt_config_file(argv[i])) {
+            QString str(argv[i]);
+            ftsPrep.setNewFile(str);
+        }
+    }
+    ftsPrep.run();
+
+}
+
+int main(int argc, char *argv[]) {
 #ifdef Q_WS_X11
     XInitThreads();
 #endif
 
-    QApplication app ( argc, argv );
+    QApplication app(argc, argv);
 
 
-    MainWindow* mainwidget = new MainWindow();
+    MainWindow *mainwidget = new MainWindow();
+
+    if (argc) {
+        preprocess(argc, argv);
+        unsigned i;
+        for (i = 0; i < argc; i++) {
+            QString str(argv[i]);
+            if (isnt_config_file(argv[i])) {
+                str.append(".cfg");
+            }
+            mainwidget->MySimpleViewWidget->addTimeSeries(str);
+        }
+    }
 
     mainwidget->show();
     return app.exec();

--- a/FTSPlotMain.cpp
+++ b/FTSPlotMain.cpp
@@ -60,10 +60,10 @@ int main(int argc, char *argv[]) {
 
     MainWindow *mainwidget = new MainWindow();
 
-    if (argc) {
+    if (argc > 1) {
         preprocess(argc, argv);
         unsigned i;
-        for (i = 0; i < argc; i++) {
+        for (i = 1; i < argc; i++) {
             QString str(argv[i]);
             if (isnt_config_file(argv[i])) {
                 str.append(".cfg");

--- a/FTSPlotMain.cpp
+++ b/FTSPlotMain.cpp
@@ -44,9 +44,9 @@ void preprocess(int argc, char *argv[]) {
         if (isnt_config_file(argv[i])) {
             QString str(argv[i]);
             ftsPrep.setNewFile(str);
+            ftsPrep.run();
         }
     }
-    ftsPrep.run();
 
 }
 

--- a/FTSPrep.h
+++ b/FTSPrep.h
@@ -49,6 +49,8 @@ public:
     void setProgressGranularity( quint64 gran = 2048 );
     ResumeData getResumeData();
 
+    void run();
+
 public slots:
     void stopforResume();
 
@@ -56,8 +58,6 @@ signals:
     void QDTexception( QString msg );
     void progressUpdate( int totalProgress, int level, int levelProgress );
 
-protected:
-    void run();
 
 private:
     enum workstate {ready, busy};

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -26,7 +26,7 @@
 
 using namespace FTSPlot;
 
-class MainWindow : public QMainWindow, private Ui::MainWindow
+class MainWindow : public QMainWindow, public Ui::MainWindow
 {
     Q_OBJECT
 public:


### PR DESCRIPTION
Hi. First step to a better integration of the tool.
I could get through the mess of Qt and cmake compilation to extract a C library, so I modified the FTSPlot main entrypoint to accept command line arguments, which means now you can do the following:
```
FTSPlot path/to/first/file.cfg path/to/binary/file.bin
```
And it will automatically plot the first file and FTSPrep the second and plot it as well.